### PR TITLE
Fixed: requests library was missing from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+certifi==2017.7.27.1
+chardet==3.0.4
+idna==2.6
+isodate==0.5.4
+negotiator2==2.0.1
+pyparsing==2.2.0
+rdflib==4.2.2
+requests==2.18.4
+tornado==4.5.2
+trilpy==0.0.1
+urllib3==1.22
+uuid==1.30

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
         "negotiator2",
         "rdflib",
         "tornado",
-        "uuid"
+        "uuid",
+        "requests"
     ],
     test_suite="tests",
     cmdclass={


### PR DESCRIPTION
The requests library was missing from the list of dependencies. This commit also adds a 'requirements.txt' file so that the dependencies can be installed using pip (pip -r requirements.txt).